### PR TITLE
fix size for sheep farm

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -361,7 +361,7 @@
     \tcbox[raster multicolumn=2, % Work Clothes
            raster multirow=2]{
         \begin{tikzpicture}
-            \farmnode{(0,0)}{Wool}{1}{Sheep_Farm}{2×3}{3}
+            \farmnode{(0,0)}{Wool}{1}{Sheep_Farm}{3×3}{3}
             \consnode{(2,0)}{Work_clothes}{1}{Framework_Knitters}{Farmers/650,Workers/650}
             \connect{Wool}{Work_clothes}
         \end{tikzpicture}}

--- a/main.tex
+++ b/main.tex
@@ -258,7 +258,7 @@
             \tcbox[raster multicolumn=3, % Sails
                   raster multirow=3]{
                 \begin{tikzpicture}
-                    \farmnode{(0,0)}{Wool}{1}{Sheep_Farm}{2×3}{3}
+                    \farmnode{(0,0)}{Wool}{1}{Sheep_Farm}{3×3}{3}
                     \prodnode{(3,0)}{Sails}{1}{Sailmakers_(Old_World)}
                     \connect{Wool}{Sails}
                 \end{tikzpicture}


### PR DESCRIPTION
The size for the ship farm should be (3x3) instead of (2x3) according to https://anno1800.fandom.com/wiki/Sheep_Farm.